### PR TITLE
Edit replay folder

### DIFF
--- a/Source/Core/Common/CommonPaths.h
+++ b/Source/Core/Common/CommonPaths.h
@@ -6,11 +6,6 @@
 // Directory separators, do we need this?
 #define DIR_SEP "/"
 #define DIR_SEP_CHR '/'
-#ifdef _WIN32
-#define CROSS_PLAT_DIR_SEP "\\"
-#else
-#define CROSS_PLAT_DIR_SEP "/"
-#endif
 
 // The user data dir
 #define ROOT_DIR "."

--- a/Source/Core/Common/CommonPaths.h
+++ b/Source/Core/Common/CommonPaths.h
@@ -6,6 +6,11 @@
 // Directory separators, do we need this?
 #define DIR_SEP "/"
 #define DIR_SEP_CHR '/'
+#ifdef _WIN32
+#define CROSS_PLAT_DIR_SEP "\\"
+#else
+#define CROSS_PLAT_DIR_SEP "/"
+#endif
 
 // The user data dir
 #define ROOT_DIR "."

--- a/Source/Core/Common/FileUtil.cpp
+++ b/Source/Core/Common/FileUtil.cpp
@@ -904,6 +904,7 @@ std::string GetHomeDirectory()
     const char* home = getenv("USERPROFILE");
     homeDir = std::string(home) + "\\Documents";
   }
+  std::replace(homeDir.begin(), homeDir.end(), '\\', '/');
 #else
   const char* home = getenv("HOME");
   homeDir = std::string(home);

--- a/Source/Core/Common/FileUtil.h
+++ b/Source/Core/Common/FileUtil.h
@@ -227,6 +227,8 @@ std::string GetBundleDirectory();
 std::string GetExePath();
 std::string GetExeDirectory();
 
+std::string GetHomeDirectory();
+
 bool WriteStringToFile(const std::string& filename, std::string_view str);
 bool ReadFileToString(const std::string& filename, std::string& str);
 

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -599,7 +599,7 @@ void SConfig::LoadBrawlbackSettings(IniFile& ini) {
 
     brawlback->Get("SaveReplays", &m_brawlbackSaveReplays, true);
 
-    const auto default_replay_dir = File::GetHomeDirectory() + CROSS_PLAT_DIR_SEP + "Brawlback";
+    const auto default_replay_dir = File::GetHomeDirectory() + DIR_SEP + "Brawlback";
     brawlback->Get("ReplaysDirectory", &m_brawlbackReplayDir, default_replay_dir);
 }
 

--- a/Source/Core/Core/ConfigManager.cpp
+++ b/Source/Core/Core/ConfigManager.cpp
@@ -330,6 +330,9 @@ void SConfig::SaveBrawlbackSettings(IniFile& ini) {
     brawlback->Set("CustomNetplayPort", m_slippiNetplayPort);
     brawlback->Set("ForceLanIP", m_slippiForceLanIp);
     brawlback->Set("LanIP", m_slippiLanIp);
+
+    brawlback->Set("SaveReplays", m_brawlbackSaveReplays);
+    brawlback->Set("ReplaysDirectory", m_brawlbackReplayDir);
 }
 
 void SConfig::LoadSettings()
@@ -593,6 +596,11 @@ void SConfig::LoadBrawlbackSettings(IniFile& ini) {
     brawlback->Get("CustomNetplayPort", &m_slippiNetplayPort, 7779);
     brawlback->Get("ForceLanIP", &m_slippiForceLanIp, false);
     brawlback->Get("LanIP", &m_slippiLanIp, "");
+
+    brawlback->Get("SaveReplays", &m_brawlbackSaveReplays, true);
+
+    const auto default_replay_dir = File::GetHomeDirectory() + CROSS_PLAT_DIR_SEP + "Brawlback";
+    brawlback->Get("ReplaysDirectory", &m_brawlbackReplayDir, default_replay_dir);
 }
 
 void SConfig::ResetRunningGameMetadata()

--- a/Source/Core/Core/ConfigManager.h
+++ b/Source/Core/Core/ConfigManager.h
@@ -104,10 +104,8 @@ struct SConfig
   bool bDisableICache = false;
 
     // Slippi
-	bool m_slippiSaveReplays = true;
-	int m_slippiEnableQuickChat = 2; // Off
-	bool m_slippiReplayMonthFolders = false;
-	std::string m_strSlippiReplayDir;
+	bool m_brawlbackSaveReplays = true;
+	std::string m_brawlbackReplayDir;
 	bool m_slippiForceNetplayPort = false;
 	int m_slippiNetplayPort;
 	bool m_slippiForceLanIp = false;

--- a/Source/Core/Core/HW/EXI/EXIBrawlback.cpp
+++ b/Source/Core/Core/HW/EXI/EXIBrawlback.cpp
@@ -1129,17 +1129,26 @@ void CEXIBrawlback::handleFighter(double* payload)
 }
 void CEXIBrawlback::handleEndGame()
 {
-  this->curReplaySerialized = json::to_ubjson(this->curReplay);
+  //TODO: when starting game, check the saveReplays flag and doin't bother writing to JSON obj
+  // if replays are disabled?
 
-  const auto p1 = std::chrono::system_clock::now();
-  const auto timestamp = std::chrono::duration_cast<std::chrono::seconds>(p1.time_since_epoch()).count();
-  writeToFile("replay_" + std::to_string(timestamp) + ".brba", this->curReplaySerialized.data(),
-              this->curReplaySerialized.size());
+  //TODO: safe to read config here?
+  if (SConfig::GetInstance().m_brawlbackSaveReplays)
+  {
+    this->curReplaySerialized = json::to_ubjson(this->curReplay);
+
+    const auto p1 = std::chrono::system_clock::now();
+    const auto timestamp =
+        std::chrono::duration_cast<std::chrono::seconds>(p1.time_since_epoch()).count();
+    writeToFile("replay_" + std::to_string(timestamp) + ".brba", this->curReplaySerialized.data(),
+                this->curReplaySerialized.size());
+  }
 }
 void CEXIBrawlback::handleGetNumberReplayFiles()
 {
-  std::string path = "./";
-  for (const auto& entry : fs::directory_iterator(path))
+  //TODO: is it safe to read from the config here? could it be written to from another thread?
+  const auto replay_dir = SConfig::GetInstance().m_brawlbackReplayDir;
+  for (const auto& entry : fs::directory_iterator(replay_dir))
   {
     if (entry.path().string().contains("replay_"))
     {

--- a/Source/Core/Core/HW/EXI/EXIBrawlback.cpp
+++ b/Source/Core/Core/HW/EXI/EXIBrawlback.cpp
@@ -1140,8 +1140,18 @@ void CEXIBrawlback::handleEndGame()
     const auto p1 = std::chrono::system_clock::now();
     const auto timestamp =
         std::chrono::duration_cast<std::chrono::seconds>(p1.time_since_epoch()).count();
-    writeToFile("replay_" + std::to_string(timestamp) + ".brba", this->curReplaySerialized.data(),
-                this->curReplaySerialized.size());
+
+    auto replaydir = SConfig::GetInstance().m_brawlbackReplayDir;
+    if (fs::is_directory(replaydir) || fs::create_directory(replaydir))
+    {
+      auto filename = fmt::format(FMT_STRING("{}/replay_{}.brba"), replaydir, timestamp);
+      writeToFile(filename, this->curReplaySerialized.data(), this->curReplaySerialized.size());
+    }
+    else
+    {
+      auto error_string = fmt::format(FMT_STRING("Failed to create replay directory: {}"), replaydir);
+      ERROR_LOG(BRAWLBACK, error_string.c_str());
+    }
   }
 }
 void CEXIBrawlback::handleGetNumberReplayFiles()

--- a/Source/Core/DolphinQt/Settings/BrawlbackPane.cpp
+++ b/Source/Core/DolphinQt/Settings/BrawlbackPane.cpp
@@ -1,4 +1,5 @@
 #include <QGridLayout>
+#include <QGroupBox>
 
 #include "Common/Config/Config.h"
 #include "Core/ConfigManager.h"
@@ -7,6 +8,7 @@
 BrawlbackPane::BrawlbackPane()
 {
   CreateWidgets();
+  LayoutWidgets();
   LoadSettings();
   ConnectWidgets();
 }
@@ -22,6 +24,10 @@ void BrawlbackPane::CreateWidgets()
   m_custom_netplay_port->setMinimum(1);
   m_custom_netplay_port->setMaximum(65535);
 
+  // Fix spin box sizes so they don't stretch to column size
+  m_delay_frames->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+  m_custom_netplay_port->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+
   m_force_lan_ip = new QCheckBox(tr("Force LAN IP"));
   m_lan_ip = new QLineEdit();
   {
@@ -30,23 +36,55 @@ void BrawlbackPane::CreateWidgets()
     m_lan_ip->setSizePolicy(size_policy);
   }
 
-  auto grid = new QGridLayout(this);
-  grid->addWidget(m_delay_frames_label, 0, 0);
-  grid->addWidget(m_delay_frames, 0, 1);
-  grid->addWidget(m_force_custom_netplay_port, 1, 0);
-  grid->addWidget(m_custom_netplay_port, 1, 1);
-  grid->addWidget(m_force_lan_ip, 2, 0);
-  grid->addWidget(m_lan_ip, 2, 1);
-
-  // Fix spin box sizes so they don't stretch to column size
-  m_delay_frames->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-  m_custom_netplay_port->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-
-  auto hSpacer = new QSpacerItem(0, 0, QSizePolicy::Expanding, QSizePolicy::Minimum);
-  grid->addItem(hSpacer, 0, grid->columnCount());
-  auto vSpacer = new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding);
-  grid->addItem(vSpacer, grid->rowCount(), 0);
+  m_save_replays = new QCheckBox(tr("Save Brawlback Replays"));
+  m_replay_folder_label = new QLabel(tr("Replay Location:"));
+  m_replays_folder = new QLineEdit();
+  m_browse_replays_folder = new QPushButton(tr("..."));
 }
+
+void BrawlbackPane::LayoutWidgets()
+{
+  auto layout = new QVBoxLayout(this);
+
+  {
+    auto onlineGroup = new QGroupBox(this);
+    onlineGroup->setTitle(tr("Online Settings"));
+    auto grid = new QGridLayout(onlineGroup);
+    grid->addWidget(m_delay_frames_label, 0, 0);
+    grid->addWidget(m_delay_frames, 0, 1);
+    grid->addWidget(m_force_custom_netplay_port, 1, 0);
+    grid->addWidget(m_custom_netplay_port, 1, 1);
+    grid->addWidget(m_force_lan_ip, 2, 0);
+    grid->addWidget(m_lan_ip, 2, 1);
+
+    auto hSpacer = new QSpacerItem(0, 0, QSizePolicy::Expanding, QSizePolicy::Minimum);
+    grid->addItem(hSpacer, 0, grid->columnCount());
+
+    layout->addWidget(onlineGroup);
+  }
+
+  {
+    auto replayGroup = new QGroupBox(this);
+    replayGroup->setTitle(tr("Replay Settings"));
+    auto grid = new QGridLayout(replayGroup);
+    int row = 0;
+    grid->addWidget(m_save_replays, row, 0, 1, -1);
+    row++;
+    grid->addWidget(m_replay_folder_label, row, 0);
+    grid->addWidget(m_replays_folder, row, 1);
+    grid->addWidget(m_browse_replays_folder, row, 2);
+
+    m_replays_folder->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
+
+    layout->addWidget(replayGroup);
+  }
+
+  {
+    auto vSpacer = new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding);
+    layout->addSpacerItem(vSpacer);
+  }
+}
+
 void BrawlbackPane::ConnectWidgets()
 {
   connect(m_delay_frames, qOverload<int>(&QSpinBox::valueChanged), this,

--- a/Source/Core/DolphinQt/Settings/BrawlbackPane.cpp
+++ b/Source/Core/DolphinQt/Settings/BrawlbackPane.cpp
@@ -3,6 +3,7 @@
 
 #include "Common/Config/Config.h"
 #include "Core/ConfigManager.h"
+#include "DolphinQt/QtUtils/DolphinFileDialog.h"
 #include "DolphinQt/Settings/BrawlbackPane.h"
 
 BrawlbackPane::BrawlbackPane()
@@ -100,6 +101,16 @@ void BrawlbackPane::ConnectWidgets()
     SaveSettings();
   });
   connect(m_lan_ip, &QLineEdit::editingFinished, this, &BrawlbackPane::SaveSettings);
+
+  connect(m_save_replays, &QCheckBox::stateChanged, this, &BrawlbackPane::SaveSettings);
+  connect(m_replays_folder, &QLineEdit::editingFinished, this, &BrawlbackPane::SaveSettings);
+  connect(m_browse_replays_folder, &QPushButton::pressed, this, [this]() {
+    const auto currentReplaysPath =
+        QString::fromStdString(SConfig::GetInstance().m_brawlbackReplayDir);
+    const auto dir = DolphinFileDialog::getExistingDirectory(this, tr("Select Replay Folder"), currentReplaysPath);
+    m_replays_folder->setText(dir.isEmpty() ? currentReplaysPath : dir);
+    SaveSettings();
+  });
 }
 
 void BrawlbackPane::LoadSettings()
@@ -115,6 +126,9 @@ void BrawlbackPane::LoadSettings()
   m_force_lan_ip->setChecked(params.m_slippiForceLanIp);
   m_lan_ip->setText(QString::fromStdString(params.m_slippiLanIp));
   m_lan_ip->setVisible(params.m_slippiForceLanIp);
+
+  m_save_replays->setChecked(params.m_brawlbackSaveReplays);
+  m_replays_folder->setText(QString::fromStdString(params.m_brawlbackReplayDir));
 }
 void BrawlbackPane::SaveSettings()
 {
@@ -127,4 +141,7 @@ void BrawlbackPane::SaveSettings()
   params.m_slippiNetplayPort = m_custom_netplay_port->value();
   params.m_slippiForceLanIp = m_force_lan_ip->isChecked();
   params.m_slippiLanIp = m_lan_ip->text().toStdString();
+
+  params.m_brawlbackSaveReplays = m_save_replays->isChecked();
+  params.m_brawlbackReplayDir = m_replays_folder->text().toStdString();
 }

--- a/Source/Core/DolphinQt/Settings/BrawlbackPane.h
+++ b/Source/Core/DolphinQt/Settings/BrawlbackPane.h
@@ -5,6 +5,7 @@
 #include <QLineEdit>
 #include <QSpinBox>
 #include <QWidget>
+#include <QPushButton>
 
 class BrawlbackPane : public QWidget
 {
@@ -14,14 +15,22 @@ public:
 
 private:
   void CreateWidgets();
+  void LayoutWidgets();
   void ConnectWidgets();
   void LoadSettings();
   void SaveSettings();
 
+  //Online settings
   QLabel* m_delay_frames_label = nullptr;
   QSpinBox* m_delay_frames = nullptr;
   QCheckBox* m_force_custom_netplay_port = nullptr;
   QSpinBox* m_custom_netplay_port = nullptr;
   QCheckBox* m_force_lan_ip = nullptr;
   QLineEdit* m_lan_ip = nullptr;
+
+  //Replay settings
+  QCheckBox* m_save_replays = nullptr;
+  QLabel* m_replay_folder_label = nullptr;
+  QLineEdit* m_replays_folder = nullptr;
+  QPushButton* m_browse_replays_folder = nullptr;
 };


### PR DESCRIPTION
Added settings to brawlback pane for settings replay enabled and replays directory.

Ideally should be tested by a mac and linux user to make sure default paths work as expected.

I tried hooking these settings into the replays logic in CEXIBrawlback, but I think there could be some issues.. It doesn't look like it's really safe to read from the config in CEXIBrawback, because the handler functions would be running in another thread (while UI thread could edit config?). To address this I think we should cache these settings somewhere. Maybe we can read during the CEXIBrawlback constructor? not sure what thread this runs in......

left some TODO: comments relating to this and what to do at the start of a match if replays are disabled.