### PR TITLE
Replays impl code fixes

### DIFF
--- a/Source/Core/Core/HW/EXI/EXIBrawlback.cpp
+++ b/Source/Core/Core/HW/EXI/EXIBrawlback.cpp
@@ -280,12 +280,13 @@ PlayerFrameData CreateDummyPlayerFrameData(u32 frame, u8 playerIdx)
 // this is called every frame at the beginning of the frame
 void CEXIBrawlback::handleLocalPadData(u8* data)
 {
-  PlayerFrameData* playerFramedata = (PlayerFrameData*)data;
+  PlayerFrameData playerFramedata;
+  std::memcpy(&playerFramedata, data, sizeof(PlayerFrameData));
   int idx = 0;
   // first 4 bytes are current game frame
   u32 frame = SlippiUtility::Mem::readWord(data, idx, 999, 0);  // properly switched endianness
-  u8 playerIdx = playerFramedata->playerIdx;
-  playerFramedata->frame = frame;  // properly switched endianness
+  u8 playerIdx = playerFramedata.playerIdx;
+  playerFramedata.frame = frame;  // properly switched endianness
 
   if (frame == GAME_START_FRAME)
   {
@@ -328,7 +329,7 @@ void CEXIBrawlback::handleLocalPadData(u8* data)
   else
   {
     // store these local inputs (with frame delay)
-    this->storeLocalInputs(playerFramedata);
+    this->storeLocalInputs(&playerFramedata);
     // broadcasts local inputs
     this->handleSendInputs(frame);
 

--- a/Source/Core/Core/HW/EXI/EXIBrawlback.cpp
+++ b/Source/Core/Core/HW/EXI/EXIBrawlback.cpp
@@ -1215,8 +1215,7 @@ void CEXIBrawlback::handleReplaysStruct(u8* payload)
   Replay replay;
   std::memcpy(&replay, payload, sizeof(Replay));
 
-  //Replay* replay = (Replay*)payload;
-  auto frameName = "frame_" + replay.frameCounter;
+  const auto frameName = fmt::format("frame_{}", replay.frameCounter);
   this->replayJson[frameName]["persistentFrameCounter"] = replay.persistentFrameCounter;
   for (int i = 0; i < replay.numItems; i++)
   {

--- a/Source/Core/Core/HW/EXI/EXIBrawlback.h
+++ b/Source/Core/Core/HW/EXI/EXIBrawlback.h
@@ -75,7 +75,7 @@ private:
   int localPlayerIdx = -1;
   u8 numPlayers = 0;
   bool hasGameStarted = false;
-  std::unique_ptr<GameSettings> gameSettings;
+  GameSettings gameSettings;
   // -------------------------------
 
   // --- Time sync


### PR DESCRIPTION
Some fixes to your branch.

See comment in CEXIBrawlback::ProcessGameSettings

The code was written kind of weird, you copied a pointer to the gamesettings member, called it mergedGameSettings, then edited that. I'm not sure why it wasn't using gamesettings member directly

I changed GameSettings member to be a value instead of a pointer (it didn't need to be a pointer), so I kept what you were doing by making mergedGameSettings a reference to that. As I mention in comment though, this is kinda weird, we should just access teh gamesetings member directly - maybe you meant to make a copy of it for mergedGameSettings?