### PR TITLE
Fix/gamecube pane crash

### DIFF
--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -116,6 +116,7 @@ bool IsSettingSaveable(const Config::Location& config_location)
       &Config::MAIN_WIIMOTE_ENABLE_SPEAKER.GetLocation(),
       &Config::MAIN_CONNECT_WIIMOTES_FOR_CONTROLLER_INTERFACE.GetLocation(),
       &Config::MAIN_SLOT_A.GetLocation(),
+      // BRAWLBACK: disable saving slot B (locked to Brawlback EXI device)
       &Config::MAIN_SLOT_B.GetLocation(),
       &Config::MAIN_SERIAL_PORT_1.GetLocation(),
       &Config::GetInfoForSIDevice(0).GetLocation(),

--- a/Source/Core/DolphinQt/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.cpp
@@ -87,17 +87,14 @@ void GameCubePane::CreateWidgets()
 
   for (ExpansionInterface::Slot slot : ExpansionInterface::SLOTS)
   {
-    if (slot != ExpansionInterface::Slot::B)
-    {
-      m_slot_combos[slot] = new QComboBox(device_box);
-      m_slot_combos[slot]->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
-      m_slot_buttons[slot] = new NonDefaultQPushButton(tr("..."), device_box);
-      m_slot_buttons[slot]->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-    }
+    m_slot_combos[slot] = new QComboBox(device_box);
+    m_slot_combos[slot]->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
+    m_slot_buttons[slot] = new NonDefaultQPushButton(tr("..."), device_box);
+    m_slot_buttons[slot]->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
   }
 
+  for (ExpansionInterface::Slot slot : ExpansionInterface::MEMCARD_SLOTS)
   {
-    auto slot = ExpansionInterface::Slot::A;
     m_memcard_path_layouts[slot] = new QHBoxLayout();
     m_memcard_path_labels[slot] = new QLabel(tr("Memory Card Path:"));
     m_memcard_paths[slot] = new QLineEdit();
@@ -165,6 +162,20 @@ void GameCubePane::CreateWidgets()
 
     ++row;
     device_layout->addLayout(m_gci_path_layouts[ExpansionInterface::Slot::A], row, 0, 1, 3);
+
+    ++row;
+    device_layout->addWidget(new QLabel(tr("Slot B:")), row, 0);
+    device_layout->addWidget(m_slot_combos[ExpansionInterface::Slot::B], row, 1);
+    device_layout->addWidget(m_slot_buttons[ExpansionInterface::Slot::B], row, 2);
+
+    ++row;
+    device_layout->addLayout(m_memcard_path_layouts[ExpansionInterface::Slot::B], row, 0, 1, 3);
+
+    ++row;
+    device_layout->addLayout(m_agp_path_layouts[ExpansionInterface::Slot::B], row, 0, 1, 3);
+
+    ++row;
+    device_layout->addLayout(m_gci_path_layouts[ExpansionInterface::Slot::B], row, 0, 1, 3);
 
     ++row;
     device_layout->addWidget(new QLabel(tr("SP1:")), row, 0);

--- a/Source/Core/DolphinQt/Settings/GameCubePane.cpp
+++ b/Source/Core/DolphinQt/Settings/GameCubePane.cpp
@@ -233,6 +233,10 @@ void GameCubePane::CreateWidgets()
   layout->addStretch();
 
   setLayout(layout);
+
+  // BRAWLBACK: disable slot B combo box (should always be set to brawlback)
+  m_slot_combos[ExpansionInterface::Slot::B]->setEnabled(false);
+  m_slot_combos[ExpansionInterface::Slot::B]->setToolTip(tr("Setting locked in this fork of Dolphin"));
 }
 
 void GameCubePane::ConnectWidgets()


### PR DESCRIPTION
Instead of removing slotB setting entirely, just disable the control, seems like this is easier to maintain.