### PR TITLE
Feature/sync sd file time

### DIFF
--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -173,6 +173,10 @@ const Info<bool>& GetInfoForSimulateKonga(int channel)
 const Info<bool> MAIN_WII_SD_CARD{{System::Main, "Core", "WiiSDCard"}, true};
 const Info<bool> MAIN_WII_SD_CARD_ENABLE_FOLDER_SYNC{
     {System::Main, "Core", "WiiSDCardEnableFolderSync"}, false};
+
+const Info<std::string> MAIN_WII_SD_SYNC_TIME_FILE{{System::Main, "Core", "WiiSDSyncTimeFile"}, ""};
+const Info<s64> MAIN_WII_SD_LAST_SYNC_TIME{{System::Main, "Core", "WiiSDLastSyncTime"}, 0};
+
 const Info<bool> MAIN_WII_KEYBOARD{{System::Main, "Core", "WiiKeyboard"}, false};
 const Info<bool> MAIN_WIIMOTE_CONTINUOUS_SCANNING{
     {System::Main, "Core", "WiimoteContinuousScanning"}, false};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -96,6 +96,10 @@ const Info<bool>& GetInfoForAdapterRumble(int channel);
 const Info<bool>& GetInfoForSimulateKonga(int channel);
 extern const Info<bool> MAIN_WII_SD_CARD;
 extern const Info<bool> MAIN_WII_SD_CARD_ENABLE_FOLDER_SYNC;
+
+extern const Info<std::string> MAIN_WII_SD_SYNC_TIME_FILE;
+extern const Info<s64> MAIN_WII_SD_LAST_SYNC_TIME;
+
 extern const Info<bool> MAIN_WII_KEYBOARD;
 extern const Info<bool> MAIN_WIIMOTE_CONTINUOUS_SCANNING;
 extern const Info<bool> MAIN_WIIMOTE_ENABLE_SPEAKER;

--- a/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
+++ b/Source/Core/Core/ConfigLoaders/IsSettingSaveable.cpp
@@ -111,6 +111,8 @@ bool IsSettingSaveable(const Config::Location& config_location)
       &Config::MAIN_TIMING_VARIANCE.GetLocation(),
       &Config::MAIN_WII_SD_CARD.GetLocation(),
       &Config::MAIN_WII_SD_CARD_ENABLE_FOLDER_SYNC.GetLocation(),
+      &Config::MAIN_WII_SD_SYNC_TIME_FILE.GetLocation(),
+      &Config::MAIN_WII_SD_LAST_SYNC_TIME.GetLocation(),
       &Config::MAIN_WII_KEYBOARD.GetLocation(),
       &Config::MAIN_WIIMOTE_CONTINUOUS_SCANNING.GetLocation(),
       &Config::MAIN_WIIMOTE_ENABLE_SPEAKER.GetLocation(),

--- a/Source/Core/Core/Core.cpp
+++ b/Source/Core/Core/Core.cpp
@@ -484,13 +484,50 @@ static void EmuThread(std::unique_ptr<BootParameters> boot, WindowSystemInfo wsi
   const bool delete_savestate =
       boot_session_data.GetDeleteSavestate() == DeleteSavestateAfterBoot::Yes;
 
-  bool sync_sd_folder = core_parameter.bWii && Config::Get(Config::MAIN_WII_SD_CARD) &&
-                        Config::Get(Config::MAIN_WII_SD_CARD_ENABLE_FOLDER_SYNC);
-  if (sync_sd_folder)
-    sync_sd_folder = Common::SyncSDFolderToSDImage(Core::WantsDeterminism());
+  const bool sd_folder_synced = [&]() {
+    const bool sync_enabled = core_parameter.bWii && Config::Get(Config::MAIN_WII_SD_CARD) &&
+                              Config::Get(Config::MAIN_WII_SD_CARD_ENABLE_FOLDER_SYNC);
 
-  Common::ScopeGuard sd_folder_sync_guard{[sync_sd_folder] {
-    if (sync_sd_folder && Config::Get(Config::MAIN_ALLOW_SD_WRITES))
+    if (!sync_enabled)
+    {
+      return false;
+    }
+
+    const auto sync_time_file = Config::Get(Config::MAIN_WII_SD_SYNC_TIME_FILE);
+
+    // If sync time file does not exist, do sd sync as usual
+    if (!File::Exists(sync_time_file))
+    {
+      INFO_LOG_FMT(CONSOLE, "SD sync time file does not exist (\"{}\"), syncing SD folder.", sync_time_file);
+      Config::SetBase(Config::MAIN_WII_SD_LAST_SYNC_TIME, 0);
+      return Common::SyncSDFolderToSDImage(Core::WantsDeterminism());
+    }
+
+    // Otherwise, check sync file timestamp to see if sd is up to date
+    const auto last_write_timepoint = std::filesystem::last_write_time(sync_time_file);
+    const auto last_write_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                        last_write_timepoint.time_since_epoch())
+                                        .count();
+    const auto saved_write_time = Config::Get(Config::MAIN_WII_SD_LAST_SYNC_TIME);
+    if (saved_write_time < last_write_time_ms)
+    {
+      // sync AND update saved_write_time
+      const auto sync_success = Common::SyncSDFolderToSDImage(Core::WantsDeterminism());
+      if (sync_success)
+      {
+        Config::SetBase(Config::MAIN_WII_SD_LAST_SYNC_TIME, last_write_time_ms);
+      }
+      return sync_success;
+    }
+    else
+    {
+      INFO_LOG_FMT(CONSOLE, "SD is up to date based on sync file timestamp, do not sync SD folder.");
+      return false;
+    }
+  }();
+
+  Common::ScopeGuard sd_folder_sync_guard{[sd_folder_synced] {
+    if (sd_folder_synced && Config::Get(Config::MAIN_ALLOW_SD_WRITES))
       Common::SyncSDImageToSDFolder();
   }};
 

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -216,6 +216,23 @@ void WiiPane::CreateSDCard()
     ++row;
   }
 
+  //TODO: only show these options to developers (maybe make checkbox for "show developer options")
+  {
+    auto hlayout = new QHBoxLayout;
+    m_sd_sync_file_edit =
+        new QLineEdit(QString::fromStdString(Config::Get(Config::MAIN_WII_SD_SYNC_TIME_FILE)));
+    connect(m_sd_sync_file_edit, &QLineEdit::editingFinished,
+            [this] { SetSDSyncTimeFile( m_sd_sync_file_edit->text()); });
+    QPushButton* browse = new NonDefaultQPushButton(QStringLiteral("..."));
+    connect(browse, &QPushButton::clicked, this, &WiiPane::BrowseSDSyncTimeFile);
+    hlayout->addWidget(new QLabel(tr("SD Sync File:")));
+    hlayout->addWidget(m_sd_sync_file_edit);
+    hlayout->addWidget(browse);
+
+    sd_settings_group_layout->addLayout(hlayout, row, 0, 1, 2);
+    ++row;
+  }
+
   m_sd_pack_button = new NonDefaultQPushButton(tr("Convert Folder to File Now"));
   m_sd_unpack_button = new NonDefaultQPushButton(tr("Convert File to Folder Now"));
   connect(m_sd_pack_button, &QPushButton::clicked, [this] {
@@ -440,3 +457,23 @@ void WiiPane::SetSDSyncFolder(const QString& path)
   Config::SetBase(Config::MAIN_WII_SD_CARD_SYNC_FOLDER_PATH, path.toStdString());
   SignalBlocking(m_sd_sync_folder_edit)->setText(path);
 }
+
+void WiiPane::BrowseSDSyncTimeFile()
+{
+  QString file = QDir::toNativeSeparators(DolphinFileDialog::getSaveFileName(
+      this,
+      tr("Select a File to track timestamp for syncing SD image"),
+      {},{},nullptr,
+      QFileDialog::Option::DontConfirmOverwrite));
+
+
+  if (!file.isEmpty())
+    SetSDSyncTimeFile(file);
+}
+
+void WiiPane::SetSDSyncTimeFile(const QString& path)
+{
+  Config::SetBase(Config::MAIN_WII_SD_SYNC_TIME_FILE, path.toStdString());
+  SignalBlocking(m_sd_sync_file_edit)->setText(path);
+}
+

--- a/Source/Core/DolphinQt/Settings/WiiPane.cpp
+++ b/Source/Core/DolphinQt/Settings/WiiPane.cpp
@@ -216,7 +216,6 @@ void WiiPane::CreateSDCard()
     ++row;
   }
 
-  //TODO: only show these options to developers (maybe make checkbox for "show developer options")
   {
     auto hlayout = new QHBoxLayout;
     m_sd_sync_file_edit =
@@ -460,15 +459,14 @@ void WiiPane::SetSDSyncFolder(const QString& path)
 
 void WiiPane::BrowseSDSyncTimeFile()
 {
-  QString file = QDir::toNativeSeparators(DolphinFileDialog::getSaveFileName(
-      this,
-      tr("Select a File to track timestamp for syncing SD image"),
-      {},{},nullptr,
+  const auto file = QDir::toNativeSeparators(DolphinFileDialog::getSaveFileName(
+      this, tr("Select a File to track timestamp for syncing SD image"), {}, {}, nullptr,
       QFileDialog::Option::DontConfirmOverwrite));
 
-
   if (!file.isEmpty())
+  {
     SetSDSyncTimeFile(file);
+  }
 }
 
 void WiiPane::SetSDSyncTimeFile(const QString& path)

--- a/Source/Core/DolphinQt/Settings/WiiPane.h
+++ b/Source/Core/DolphinQt/Settings/WiiPane.h
@@ -44,6 +44,9 @@ private:
   void BrowseSDSyncFolder();
   void SetSDSyncFolder(const QString& path);
 
+  void BrowseSDSyncTimeFile();
+  void SetSDSyncTimeFile(const QString& path);
+
   // Widgets
   QVBoxLayout* m_main_layout;
 
@@ -64,6 +67,7 @@ private:
   QCheckBox* m_sync_sd_folder_checkbox;
   QLineEdit* m_sd_raw_edit;
   QLineEdit* m_sd_sync_folder_edit;
+  QLineEdit* m_sd_sync_file_edit;
   QPushButton* m_sd_pack_button;
   QPushButton* m_sd_unpack_button;
 


### PR DESCRIPTION
For use with https://github.com/Brawlback-Team/brawlback-asm/pull/36 

Set .latest_sd_update_time as the WiiSDSyncTimeFile option to make dolphin track this file's timestamp to determine whether to rebuild SD card.