### PR TITLE
Fix fmtlib v11 compile-time errors

### DIFF
--- a/Source/Core/Common/Logging/Log.h
+++ b/Source/Core/Common/Logging/Log.h
@@ -100,7 +100,13 @@ void GenericLogFmt(LogLevel level, LogType type, const char* file, int line, con
   static_assert(NumFields == sizeof...(args),
                 "Unexpected number of replacement fields in format string; did you pass too few or "
                 "too many arguments?");
-  GenericLogFmtImpl(level, type, file, line, format, fmt::make_format_args(args...));
+
+#if FMT_VERSION >= 110000
+  auto&& format_str = fmt::format_string<Args...>(format);
+#else
+  auto&& format_str = format;
+#endif
+  GenericLogFmtImpl(level, type, file, line, format_str, fmt::make_format_args(args...));
 }
 }  // namespace Common::Log
 

--- a/Source/Core/Common/MsgHandler.h
+++ b/Source/Core/Common/MsgHandler.h
@@ -41,12 +41,17 @@ bool MsgAlertFmt(bool yes_no, MsgType style, Common::Log::LogType log_type, cons
   static_assert(NumFields == sizeof...(args),
                 "Unexpected number of replacement fields in format string; did you pass too few or "
                 "too many arguments?");
-#if FMT_VERSION >= 90000
+#if FMT_VERSION >= 110000
+  static_assert(std::is_base_of_v<fmt::detail::compile_string, S>);
+  auto&& format_str = fmt::format_string<Args...>(format);
+#elif FMT_VERSION >= 90000
   static_assert(fmt::detail::is_compile_string<S>::value);
+  auto&& format_str = format;
 #else
   static_assert(fmt::is_compile_string<S>::value);
+  auto&& format_str = format;
 #endif
-  return MsgAlertFmtImpl(yes_no, style, log_type, file, line, format,
+  return MsgAlertFmtImpl(yes_no, style, log_type, file, line, format_str,
                          fmt::make_format_args(args...));
 }
 
@@ -60,7 +65,9 @@ bool MsgAlertFmtT(bool yes_no, MsgType style, Common::Log::LogType log_type, con
   static_assert(NumFields == sizeof...(args),
                 "Unexpected number of replacement fields in format string; did you pass too few or "
                 "too many arguments?");
-#if FMT_VERSION >= 90000
+#if FMT_VERSION >= 110000
+  static_assert(std::is_base_of_v<fmt::detail::compile_string, S>);
+#elif FMT_VERSION >= 90000
   static_assert(fmt::detail::is_compile_string<S>::value);
 #else
   static_assert(fmt::is_compile_string<S>::value);

--- a/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
+++ b/Source/Core/Core/HW/EXI/BBA/BuiltIn.cpp
@@ -686,7 +686,7 @@ bool CEXIETHERNET::BuiltInBBAInterface::SendFrame(const u8* frame, u32 size)
   }
 
   default:
-    ERROR_LOG_FMT(SP1, "Unsupported EtherType {#06x}", *ethertype);
+    ERROR_LOG_FMT(SP1, "Unsupported EtherType {:#06x}", *ethertype);
     return false;
   }
 

--- a/Source/Core/Core/HW/EXI/EXIBrawlback.cpp
+++ b/Source/Core/Core/HW/EXI/EXIBrawlback.cpp
@@ -1212,7 +1212,7 @@ void CEXIBrawlback::handleEndMatch(u8* payload)
 
   if (res != 0)
   {
-    ERROR_LOG_FMT(BRAWLBACK, "[GameReport] Got error executing request. Err code: {#d}", (int)res);
+    ERROR_LOG_FMT(BRAWLBACK, "[GameReport] Got error executing request. Err code: {:d}", (int)res);
   }
   else
   {


### PR DESCRIPTION
Fix compile-time errors when compiling with fmtlib >= v11.0. This fixes compilation on systems like Arch, which have a newer fmt version, since the system fmt is used by default.

Two of the patches are from upstream Dolphin (https://github.com/dolphin-emu/dolphin/pull/13262). The linked PR contains more info on those changes.

Another patch was added to `EXIBrawlback.cpp` to fix an incorrect format string causing a compile-time error.

This was tested with my system's fmt v11.1.4, and the bundled fmt v10.2.1 by using `USE_SYSTEM_FMT=off`.

Note I only really tested these changes by cherry-picking them out to `master`, since this branch can't compile on Linux currently. I also tested compilation on the open PR #60 that can currently compile on Linux.