### PR TITLE
Linux Compatibility Fixes for Brawlback Dolphin

### DIFF
--- a/Externals/minizip-ng/CMakeLists.txt
+++ b/Externals/minizip-ng/CMakeLists.txt
@@ -1,5 +1,8 @@
 project(minizip C)
 
+include(CheckFunctionExists)
+include(CheckIncludeFile)
+
 add_library(minizip STATIC
   minizip-ng/mz.h
   minizip-ng/mz_compat.c

--- a/Source/Core/Common/MemArenaUnix.cpp
+++ b/Source/Core/Common/MemArenaUnix.cpp
@@ -110,6 +110,29 @@ void MemArena::UnmapFromMemoryRegion(void* view, size_t size)
     NOTICE_LOG_FMT(MEMMAP, "mmap failed");
 }
 
+// Windows PAGE_* constants mapped to POSIX PROT_* equivalents
+// PAGE_READONLY = 0x02, PAGE_READWRITE = 0x04
+bool MemArena::VirtualProtectMemoryRegion(void* data, size_t size, u32 flag)
+{
+  int prot;
+  if (flag == 0x02)  // PAGE_READONLY
+    prot = PROT_READ;
+  else if (flag == 0x04)  // PAGE_READWRITE
+    prot = PROT_READ | PROT_WRITE;
+  else
+  {
+    ERROR_LOG_FMT(MEMMAP, "VirtualProtectMemoryRegion: unknown protection flag 0x{:x}", flag);
+    return false;
+  }
+
+  if (mprotect(data, size, prot) != 0)
+  {
+    ERROR_LOG_FMT(MEMMAP, "mprotect failed: {}", strerror(errno));
+    return false;
+  }
+  return true;
+}
+
 LazyMemoryRegion::LazyMemoryRegion() = default;
 
 LazyMemoryRegion::~LazyMemoryRegion()

--- a/Source/Core/Core/Brawlback/include/incremental-rollback/incremental_rb.cpp
+++ b/Source/Core/Core/Brawlback/include/incremental-rollback/incremental_rb.cpp
@@ -8,6 +8,12 @@
 #include "brawlback-common/BrawlbackConstants.h"
 #include <set>
 #include <cassert>
+#include <cstdlib>
+#ifdef _WIN32
+#include <malloc.h>
+#else
+#include <mm_malloc.h>
+#endif
 #include <Common/Logging/Log.h>
 #include <Core/HW/MemoryInterface.h>
 #include <Core/HW/VideoInterface.h>
@@ -57,10 +63,10 @@ namespace IncrementalRB
   static jobsystem::context jobctx;
 
   static IncrementalRBCallbacks cbs = {};
+  static bool s_initialized = false;
+  static bool s_callbacks_registered = false;
 
-  static
-
-    TIntervalSet excludeSet;
+  static TIntervalSet excludeSet;
  
   inline u8* GetRAM()
   {
@@ -139,9 +145,12 @@ namespace IncrementalRB
   void InitState(IncrementalRBCallbacks cb)
   {
     //PROFILE_FUNCTION();
-    
+    INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - START");
+
     cbs = cb;
+    INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - Callbacks set, calling ResetAllocs");
     ResetAllocs(savestateInfo);
+    INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - ResetAllocs completed");
     #ifdef SPECIFIC_TRACKING
     std::vector<Region> staticRegions = {
         {0x806414a0, 0x806414a0 + 0x60},
@@ -353,18 +362,25 @@ namespace IncrementalRB
     TrackAlloc(GetPointer(0x92dcdf41), 0x92e90127 - 0x92dcdf41);
     TrackAlloc(GetPointer(0x92e90141), 0x935ce200 - 0x92e90141);
     #else
+    INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - Getting physical regions");
     std::array<Memory::PhysicalMemoryRegion, 4> physical_entries = GetPhysicalRegions();
+    INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - Got {} physical regions", physical_entries.size());
     for (int i = 0; i < physical_entries.size(); i++)
     {
       if (!physical_entries[i].active)
       {
+        INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - Region {} not active, skipping", i);
         continue;
       }
-
+      INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - TrackAlloc region {} ptr={} size={}",
+                   i, fmt::ptr(*physical_entries[i].out_pointer), physical_entries[i].size);
       TrackAlloc(*physical_entries[i].out_pointer, physical_entries[i].size);
+      INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - TrackAlloc region {} done", i);
     }
     // Threading Stuff
+    INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - Starting ExcludeMem calls");
     ExcludeMem(GetPointer(0x80009760), 0x805b5158 - 0x80009760); // Data Sections, BSS, Main Stack
+    INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - ExcludeMem 1/9 done");
     ExcludeMem(GetPointer(0x805bf420), 0x28);                    // ??? OSAlarm
     ExcludeMem(GetPointer(0x805bacc0), 0x28);                    // PAD OSAlarm
     ExcludeMem(GetPointer(0x805b85e0), 0x28);                    // OSALarmSleep OSAlarm
@@ -376,29 +392,71 @@ namespace IncrementalRB
     ExcludeMem(GetPointer(0x805ca260), 0x00007c00);              // Thread
     ExcludeMem(GetPointer(0x90199800), 0x00cc7c00);              // Sound
     ExcludeMem(GetPointer(0x80b8db60), 0x80c23a60 - 0x80b8db60); // Effect
+    INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - All ExcludeMem calls done");
 
     std::sort(ExcludeMemList.begin(), ExcludeMemList.end(), [](const ExcludeBuffer& a, const ExcludeBuffer& b){ return a.buffer.data < b.buffer.data; });
+    INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - ExcludeMemList sorted, size={}", ExcludeMemList.size());
 
     for (u32 i = 0; i < ExcludeMemList.size(); i++)
     {
       excludeSet.insert(ExcludeMemList[i].excludeGap);
     }
-    
+    INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - excludeSet populated, size={}", excludeSet.size());
+
     #endif
+    INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - Calling jobsystem::Initialize with {} workers", numWorkerThreads - 1);
     jobsystem::Initialize(
         numWorkerThreads -
         1);  // -1 because when we do our async and join stuff, main thread also becomes a worker
+    INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - jobsystem initialized");
+
+    INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - Checking RAM alignment: {}", fmt::ptr(GetRAM()));
     assert(IS_ALIGNED(GetRAM(), 32));  // for simd memcpy, need to be 32 byte aligned
+    INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - Checking EXRAM alignment: {}", fmt::ptr(GetEXRAM()));
     assert(IS_ALIGNED(GetEXRAM(), 32));  // for simd memcpy, need to be 32 byte aligned
 
     // allocate mem for savestates
     u64 savestateMemSize = MAX_NUM_CHANGED_PAGES * Common::PageSize();
-    for (Savestate& savestate : savestateInfo.savestates)
+    INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - Allocating savestate memory, size per state={}, count={}", savestateMemSize, MAX_SAVESTATES);
+    for (int ssIdx = 0; ssIdx < MAX_SAVESTATES; ssIdx++)
     {
+      Savestate& savestate = savestateInfo.savestates[ssIdx];
+      INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - Allocating savestate {}", ssIdx);
       void* backingMem = _mm_malloc(savestateMemSize, 32);
+      INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - Got backingMem={}", fmt::ptr(backingMem));
       assert(IS_ALIGNED(backingMem, 32));
       savestate.arena = arena_init(backingMem, savestateMemSize);
+      INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - Savestate {} arena initialized", ssIdx);
     }
+    s_initialized = true;
+    INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - COMPLETE");
+  }
+
+  void RegisterCallbacks(IncrementalRBCallbacks cb)
+  {
+    INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::RegisterCallbacks() - Storing callbacks for lazy initialization");
+    cbs = cb;
+    s_callbacks_registered = true;
+  }
+
+  bool IsInitialized()
+  {
+    return s_initialized;
+  }
+
+  void EnsureInitialized()
+  {
+    if (s_initialized)
+      return;
+
+    if (!s_callbacks_registered)
+    {
+      ERROR_LOG_FMT(BRAWLBACK, "IncrementalRB::EnsureInitialized() - Cannot initialize: callbacks not registered");
+      return;
+    }
+
+    INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::EnsureInitialized() - Performing lazy initialization");
+    InitState(cbs);
   }
 
   s32 Wrap(s32 x, s32 wrap)

--- a/Source/Core/Core/Brawlback/include/incremental-rollback/incremental_rb.h
+++ b/Source/Core/Core/Brawlback/include/incremental-rollback/incremental_rb.h
@@ -40,6 +40,16 @@ namespace IncrementalRB
     // must have been allocated with VirtualAlloc with the MEM_WRITE_WATCH flag
     // this sets our callbacks and tracks the memory block returned by GetGameStateCb and GetGamestateMemSizeCb
     void InitState(IncrementalRBCallbacks cb);
+
+    // Register callbacks without initializing - InitState will be called lazily when needed
+    void RegisterCallbacks(IncrementalRBCallbacks cb);
+
+    // Check if InitState has been called
+    bool IsInitialized();
+
+    // Ensure initialization (call InitState if not already done)
+    void EnsureInitialized();
+
     // should be called at the END of every game simulation frame. Right now, this just saves the game state
     void SaveWrittenPages(u32 frame, bool resim);
     void OnFrameEnd(s32 frame, bool isResim);

--- a/Source/Core/Core/Brawlback/include/incremental-rollback/mem.cpp
+++ b/Source/Core/Core/Brawlback/include/incremental-rollback/mem.cpp
@@ -2,8 +2,17 @@
 //#include "profiler.h"
 #include <vector>
 #include <cassert>
+#include <cerrno>
+#include <cinttypes>
+#include <cstdlib>
+#include <cstring>
 #include <set>
 #include <cmath>
+#ifdef _WIN32
+#include <malloc.h>
+#else
+#include <mm_malloc.h>
+#endif
 
 #include <Common/Logging/Log.h>
 #include <Common/MemoryUtil.h>
@@ -26,6 +35,9 @@
 #else
 #include <sys/sysinfo.h>
 #endif
+// Windows memory protection constants for cross-platform compatibility
+#define PAGE_READONLY  0x02
+#define PAGE_READWRITE 0x04
 #endif
 
 // the [i].AddressArray.Count here represents the total number of pages in this allocation
@@ -121,7 +133,7 @@ void PrintAddressArray(const TrackedBuffer& buf)
     {
         // offset from base buffer pointer that got changed
         u64 changedOffset = ((u8*)ChangedPages.Addresses[PageIndex] - BaseAddress) / pageSize;
-        printf("%llu : %llu\n", PageIndex, changedOffset);
+        printf("%" PRIu64 " : %" PRIu64 "\n", PageIndex, changedOffset);
     }
 }
 
@@ -199,8 +211,12 @@ bool GetAndResetWrittenPages(std::vector<uintptr_t>& changedPageAddresses, u64 m
             ERROR_LOG_FMT(BRAWLBACK, "WRITTEN PAGE WRITE FAILED! RESULT CODE: {}\n", result);
             if (result == 2 || result == 3)
             {
+#ifdef _WIN32
               DWORD dw = GetLastError();
               ERROR_LOG_FMT(BRAWLBACK, "WRITTEN PAGE WRITE FAILED DUE TO A FAILURE ({}) TO WRITE PROTECT. THE REASON IS: {}\n", result, dw);
+#else
+              ERROR_LOG_FMT(BRAWLBACK, "WRITTEN PAGE WRITE FAILED DUE TO A FAILURE ({}) TO WRITE PROTECT. THE REASON IS: {}\n", result, strerror(errno));
+#endif
             }
             return false;
         }
@@ -216,7 +232,12 @@ bool GetAndResetWrittenPages(std::vector<uintptr_t>& changedPageAddresses, u64 m
 // dest and src buffers must be 32 byte aligned
 // since our code generally always works with actual system pages of memory,
 // nearly (if not all) of our memcpys are on power-of-two aligned blocks of 4096kb
-void fastMemcpy(void *pvDest, void *pvSrc, size_t nBytes) 
+#ifdef _MSC_VER
+void fastMemcpy(void *pvDest, void *pvSrc, size_t nBytes)
+#else
+__attribute__((target("avx,avx2")))
+void fastMemcpy(void *pvDest, void *pvSrc, size_t nBytes)
+#endif 
 {
     assert(IS_ALIGNED(pvDest, 32));
     assert(IS_ALIGNED(pvSrc, 32));

--- a/Source/Core/Core/Brawlback/include/incremental-rollback/tiny_arena.h
+++ b/Source/Core/Core/Brawlback/include/incremental-rollback/tiny_arena.h
@@ -4,16 +4,7 @@
 
 // ARENAS
 
-#define arena_alloc_type(arena, type, num) ((type*)arena_alloc(arena, sizeof(type) * num))
-
-template <typename T>
-T* arena_alloc_and_init(Arena* arena, u32 numElements = 1)
-{
-    T* alloc = arena_alloc_type(arena, T, numElements);
-    new(alloc) T(); // because some c++ types need their ctors called
-    return alloc;
-}
-
+// Forward declarations - must come before template functions that use them
 Arena arena_init(void* backing_buffer, size_t arena_size);
 Arena arena_init(void* backing_buffer, size_t arena_size, const char* name); // name should be owning. arena takes a cpy of the ptr
 void* arena_alloc(Arena* arena, size_t alloc_size);
@@ -23,3 +14,13 @@ void arena_pop_latest(Arena* arena, void* data);
 void arena_clear(Arena* arena);
 const char* arena_get_name(Arena* arena);
 inline size_t get_free_space(Arena* arena) { return arena->backing_mem_size - arena->offset; }
+
+#define arena_alloc_type(arena, type, num) ((type*)arena_alloc(arena, sizeof(type) * num))
+
+template <typename T>
+T* arena_alloc_and_init(Arena* arena, u32 numElements = 1)
+{
+    T* alloc = arena_alloc_type(arena, T, numElements);
+    new(alloc) T(); // because some c++ types need their ctors called
+    return alloc;
+}

--- a/Source/Core/Core/Brawlback/include/incremental-rollback/util.h
+++ b/Source/Core/Core/Brawlback/include/incremental-rollback/util.h
@@ -49,7 +49,7 @@ inline T Clamp(T& value, const T& low, const T& high)
 template <typename T>
 inline T PercentOf(T x, u32 percentOutOf100)
 {
-    percentOutOf100 = Clamp(percentOutOf100, 0u, 100u);
+    percentOutOf100 = ::Clamp(percentOutOf100, 0u, 100u);
     return (x * percentOutOf100) / 100;
 }
 

--- a/Source/Core/Core/CMakeLists.txt
+++ b/Source/Core/Core/CMakeLists.txt
@@ -18,6 +18,15 @@ add_library(core
   BootManager.cpp
   BootManager.h
   Brawlback/include/json.hpp
+  Brawlback/include/incremental-rollback/incremental_rb.cpp
+  Brawlback/include/incremental-rollback/incremental_rb.h
+  Brawlback/include/incremental-rollback/job_system.cpp
+  Brawlback/include/incremental-rollback/job_system.h
+  Brawlback/include/incremental-rollback/mem.cpp
+  Brawlback/include/incremental-rollback/mem.h
+  Brawlback/include/incremental-rollback/tiny_arena.cpp
+  Brawlback/include/incremental-rollback/tiny_arena.h
+  Brawlback/include/incremental-rollback/util.h
   Brawlback/Netplay/Matchmaking.cpp
   Brawlback/Netplay/Matchmaking.h
   Brawlback/Netplay/Netplay.cpp

--- a/Source/Core/Core/HW/EXI/EXIBrawlback.cpp
+++ b/Source/Core/Core/HW/EXI/EXIBrawlback.cpp
@@ -139,6 +139,7 @@ void CEXIBrawlback::handleLoadSavestate(u8* data)
   // frame we should rollback to
   std::memcpy(&stopRollbackFrame, data, sizeof(bu32));
   stopRollbackFrame = swap_endian(stopRollbackFrame);
+  IncrementalRB::EnsureInitialized();
   IncrementalRB::Rollback(this->lastStatedFrame, stopRollbackFrame);
 }
 
@@ -355,6 +356,7 @@ void CEXIBrawlback::updateSync(bu32& locFrame, bu8 playerIdx)
     // not synchronized, rollback & resim
     INFO_LOG_FMT(BRAWLBACK, "Should rollback! frame = {} latestConfirmedFrame = {}\n", locFrame,
                  latestConfirmedFrame);
+    IncrementalRB::EnsureInitialized();
     IncrementalRB::Rollback(locFrame, latestConfirmedFrame);
     // if on frame 10 we rollback to frame 7 we need to simulate frames 7,8,9, and 10 to get to
     // where we were before. 10 - 7 + 1 = 4

--- a/Source/Core/Core/HW/EXI/EXIBrawlback.cpp
+++ b/Source/Core/Core/HW/EXI/EXIBrawlback.cpp
@@ -129,6 +129,8 @@ void CEXIBrawlback::handleCaptureSavestate(u8* data)
 
 void CEXIBrawlback::SaveState(bu32 frame)
 {
+  // Lazy initialization: only init IncrementalRB when netplay actually needs it
+  IncrementalRB::EnsureInitialized();
   IncrementalRB::SaveWrittenPages(frame - 1, this->framesToAdvance > 1 && frame - 1 < this->stopRollbackFrame);
 }
 
@@ -890,11 +892,12 @@ void CEXIBrawlback::NetplayThreadFunc()
 
       qos_success = true;
     }
+  }
 #else
 #ifdef __linux__
   // highest priority
   int priority = 7;
-  setsockopt(this->peer->socket, SOL_SOCKET, SO_PRIORITY, &priority, sizeof(priority));
+  setsockopt(this->server->socket, SOL_SOCKET, SO_PRIORITY, &priority, sizeof(priority));
 #endif
 
   // https://www.tucny.com/Home/dscp-tos
@@ -903,7 +906,6 @@ void CEXIBrawlback::NetplayThreadFunc()
   qos_success =
       setsockopt(this->server->socket, IPPROTO_IP, IP_TOS, &tos_val, sizeof(tos_val)) == 0;
 #endif
-  }
   timeout = this->isHost ? 5000 : 1000;
   while (!this->isConnected)
   {

--- a/Source/Core/Core/HW/Memmap.cpp
+++ b/Source/Core/Core/HW/Memmap.cpp
@@ -41,6 +41,12 @@
 #include <incremental-rollback/incremental_rb.h>
 #include <Core/Debugger/Debugger_SymbolMap.h>
 
+// Windows memory protection constants for cross-platform compatibility
+#ifndef _WIN32
+#define PAGE_READONLY  0x02
+#define PAGE_READWRITE 0x04
+#endif
+
 namespace Memory
 {
 
@@ -466,6 +472,9 @@ void MemoryManager::Init()
   Clear();
 
   INFO_LOG_FMT(MEMMAP, "Memory system initialized. RAM at {}", fmt::ptr(m_ram));
+
+  // Register IncrementalRB callbacks for lazy initialization
+  // Actual InitState() will be called when netplay starts (EnsureInitialized)
   IncrementalRB::IncrementalRBCallbacks cbs;
   cbs.getEXRAM = getEXRAM;
   cbs.getEXRAMMask = getExRamMask;
@@ -475,7 +484,8 @@ void MemoryManager::Init()
   cbs.getRAM = getRAM;
   cbs.getRAMSize = getRamSize;
   cbs.getPhysicalRegions = getPhysicalRegions;
-  IncrementalRB::InitState(cbs);
+  IncrementalRB::RegisterCallbacks(cbs);
+
   m_is_initialized = true;
 }
 

--- a/Source/Core/Core/HW/Wiimote.cpp
+++ b/Source/Core/Core/HW/Wiimote.cpp
@@ -80,7 +80,11 @@ HIDWiimote* GetHIDWiimoteSource(unsigned int index)
   switch (GetSource(index))
   {
   case WiimoteSource::Emulated:
-    hid_source = static_cast<WiimoteEmu::Wiimote*>(::Wiimote::GetConfig()->GetController(index));
+    // Safety check: ensure controllers have been created before accessing
+    if (::Wiimote::GetConfig()->GetControllerCount() > static_cast<int>(index))
+    {
+      hid_source = static_cast<WiimoteEmu::Wiimote*>(::Wiimote::GetConfig()->GetController(index));
+    }
     break;
 
   case WiimoteSource::Real:

--- a/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
+++ b/Source/Core/Core/IOS/FS/FileSystemProxy.cpp
@@ -19,6 +19,12 @@
 #include "Core/IOS/Uids.h"
 #include "Core/System.h"
 
+// Windows memory protection constants for cross-platform compatibility
+#ifndef _WIN32
+#define PAGE_READONLY  0x02
+#define PAGE_READWRITE 0x04
+#endif
+
 namespace IOS::HLE
 {
 using namespace IOS::HLE::FS;

--- a/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
+++ b/Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp
@@ -24,6 +24,12 @@
 #include "Core/IOS/VersionInfo.h"
 #include "Core/System.h"
 
+// Windows memory protection constants for cross-platform compatibility
+#ifndef _WIN32
+#define PAGE_READONLY  0x02
+#define PAGE_READWRITE 0x04
+#endif
+
 namespace IOS::HLE
 {
 SDIOSlot0Device::SDIOSlot0Device(EmulationKernel& ios, const std::string& device_name)

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
-find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Svg)
+find_package(Qt6 REQUIRED COMPONENTS Core Gui GuiPrivate Widgets Svg)
 message(STATUS "Found Qt version ${Qt6_VERSION}")
 
 set_property(TARGET Qt6::Core PROPERTY INTERFACE_COMPILE_FEATURES "")
@@ -420,6 +420,7 @@ target_link_libraries(dolphin-emu
 PRIVATE
   core
   Qt6::Widgets
+  Qt6::GuiPrivate
   uicommon
   imgui
   implot

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,44 @@
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    # Build tools
+    cmake gcc git pkg-config ninja
+
+    # Qt6
+    qt6.qtbase
+    qt6.qtsvg
+    qt6.wrapQtAppsHook
+
+    # Dolphin dependencies
+    libxkbcommon xorg.libXrandr xorg.libXi xorg.libX11
+    SDL2 libevdev miniupnpc lzo alsa-lib pulseaudio
+    bluez ffmpeg libusb1 pugixml cubeb libspng
+    hidapi sfml zstd lz4 xxHash mbedtls curl
+
+    # LLVM for JIT
+    llvmPackages.llvm
+
+    # Python for brawlback-asm
+    (python3.withPackages (ps: with ps; [ click requests rich ]))
+
+    # SD card tools
+    mtools
+    dosfstools
+
+    # Wine for GCTRealMate
+    wineWowPackages.stable
+  ];
+
+  # Use bundled fmt (system fmt v12+ has breaking changes)
+  CMAKE_ARGS = "-DUSE_SYSTEM_FMT=OFF";
+
+  # Wayland workaround - force X11/XCB
+  QT_QPA_PLATFORM = "xcb";
+
+  shellHook = ''
+    echo "Brawlback development shell"
+    echo "Build: mkdir -p build && cd build && cmake .. -DLINUX_LOCAL_DEV=ON -DUSE_SYSTEM_FMT=OFF && cmake --build . -j$(nproc)"
+    echo "Setup: cd build/Binaries && ln -sf ../../Data/Sys Sys"
+    echo "Run:   QT_QPA_PLATFORM=xcb ./build/Binaries/dolphin-emu"
+  '';
+}


### PR DESCRIPTION
What follows is prompted for descriptions of the changes and thought processes of these changes:

# Pull Request: Linux Compatibility Fixes for Brawlback Dolphin

## Summary

This PR adds Linux support to Brawlback Dolphin. The changes fix several crashes and build issues that occur on Linux while maintaining full backwards compatibility with Windows.

**Tested on:** Manjaro Linux (kernel 6.1.159), Qt6, GCC

**Windows Impact:** All changes are either Linux-only (guarded by `#ifdef`), or are general bug fixes that improve stability on both platforms.

---

## Commits Overview

| Commit | Description | Windows Impact |
|--------|-------------|----------------|
| c32816bb | Fix Wiimote controller crash | ✅ Improves stability |
| 9ff46d15 | Add Linux memory protection API | ✅ No impact (Linux-only) |
| 3d77aeb3 | Add IncrementalRB to CMakeLists | ✅ No impact |
| 8b36b64d | Add Qt6::GuiPrivate dependency | ⚠️ May need testing |
| 3bf5e341 | Implement lazy initialization | ✅ Improves stability |
| 88c24921 | Fix IncrementalRB Linux compat | ✅ No impact (guarded) |
| d2c5d1f7 | Fix minizip-ng CMakeLists | ✅ No impact |
| a0f76edf | Add EnsureInitialized to all Rollback paths | ✅ Fixes potential crash |

---

## Detailed Change Analysis

### Commit 1: Fix Wiimote controller crash at boot (c32816bb)

**File:** `Source/Core/Core/HW/Wiimote.cpp`

**Problem:**
On Linux, Dolphin crashed immediately at boot with:
```
vector::_M_range_check: __n (which is 0) >= this->size() (which is 0)
```

**Root Cause Analysis:**
The function `GetHIDWiimoteSource()` was called during early initialization, before any Wiimote controllers had been created. The code unconditionally accessed `GetController(index)` on an empty vector, triggering a range check exception.

The call stack was:
1. Boot sequence starts
2. `GetSource(index)` returns `WiimoteSource::Emulated`
3. `GetConfig()->GetController(index)` is called
4. Vector is empty → crash

**Why This Happened on Linux But Not Windows:**
Windows builds may have different initialization ordering, or MSVC's STL implementation may not throw on out-of-bounds access in release builds. Linux's libstdc++ has stricter bounds checking.

**The Fix:**
```cpp
case WiimoteSource::Emulated:
-    hid_source = static_cast<WiimoteEmu::Wiimote*>(::Wiimote::GetConfig()->GetController(index));
+    // Safety check: ensure controllers have been created before accessing
+    if (::Wiimote::GetConfig()->GetControllerCount() > static_cast<int>(index))
+    {
+      hid_source = static_cast<WiimoteEmu::Wiimote*>(::Wiimote::GetConfig()->GetController(index));
+    }
     break;
```

**Windows Impact:** ✅ SAFE
- This is a defensive bounds check that prevents undefined behavior
- If the vector is empty, `hid_source` remains as its initialized value (nullptr or unchanged)
- This could potentially fix rare crashes on Windows too if the timing is ever different
- No behavioral change for the normal case where controllers exist

**Thought Process:**
I considered alternative fixes:
1. **Ensure controllers are created earlier** - Would require understanding the full initialization order, risky
2. **Add bounds check** (chosen) - Minimal change, safe, follows defensive programming principles
3. **Change return type to optional** - Too invasive for a simple fix

---

### Commit 2: Add Linux memory protection API compatibility (9ff46d15)

**Files:**
- `Source/Core/Common/MemArenaUnix.cpp`
- `Source/Core/Core/IOS/FS/FileSystemProxy.cpp`
- `Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp`

**Problem:**
The IncrementalRB code uses `VirtualProtectMemoryRegion()` with Windows `PAGE_READONLY`/`PAGE_READWRITE` constants, but this function and these constants don't exist on Linux.

**Root Cause Analysis:**
The incremental rollback system needs to write-protect memory pages to track which pages have been modified (copy-on-write semantics). On Windows, this is done with `VirtualProtect()` and `PAGE_*` constants. Linux has `mprotect()` with `PROT_*` constants.

**The Fix:**

In `MemArenaUnix.cpp`, added a new function:
```cpp
// Windows PAGE_* constants mapped to POSIX PROT_* equivalents
// PAGE_READONLY = 0x02, PAGE_READWRITE = 0x04
bool MemArena::VirtualProtectMemoryRegion(void* data, size_t size, u32 flag)
{
  int prot;
  if (flag == 0x02)  // PAGE_READONLY
    prot = PROT_READ;
  else if (flag == 0x04)  // PAGE_READWRITE
    prot = PROT_READ | PROT_WRITE;
  else
  {
    ERROR_LOG_FMT(MEMMAP, "VirtualProtectMemoryRegion: unknown protection flag 0x{:x}", flag);
    return false;
  }

  if (mprotect(data, size, prot) != 0)
  {
    ERROR_LOG_FMT(MEMMAP, "mprotect failed: {}", strerror(errno));
    return false;
  }
  return true;
}
```

In IOS files, added the constant definitions for non-Windows:
```cpp
#ifndef _WIN32
#define PAGE_READONLY  0x02
#define PAGE_READWRITE 0x04
#endif
```

**Windows Impact:** ✅ SAFE
- All new code is guarded by `#ifndef _WIN32` or is in Unix-only files
- Windows continues to use its native `VirtualProtect()` implementation
- The PAGE_* constant definitions are only added on non-Windows platforms

**Thought Process:**
I chose to map the Windows constants to POSIX equivalents rather than creating a new abstraction because:
1. The existing code already uses Windows constants throughout
2. Creating a new enum would require changing many call sites
3. The mapping is simple and well-defined (readonly → read, readwrite → read+write)

---

### Commit 3: Add IncrementalRB source files to Core CMakeLists (3d77aeb3)

**File:** `Source/Core/Core/CMakeLists.txt`

**Problem:**
The incremental-rollback source files were not being compiled into the core library on Linux, causing linker errors.

**Root Cause Analysis:**
The Brawlback team likely uses Visual Studio on Windows, which has its own project files (.vcxproj). The CMakeLists.txt is used for Linux/macOS builds but wasn't updated with the IncrementalRB source files.

**The Fix:**
```cmake
 add_library(core
   ...
   Brawlback/include/json.hpp
+  Brawlback/include/incremental-rollback/incremental_rb.cpp
+  Brawlback/include/incremental-rollback/incremental_rb.h
+  Brawlback/include/incremental-rollback/job_system.cpp
+  Brawlback/include/incremental-rollback/job_system.h
+  Brawlback/include/incremental-rollback/mem.cpp
+  Brawlback/include/incremental-rollback/mem.h
+  Brawlback/include/incremental-rollback/tiny_arena.cpp
+  Brawlback/include/incremental-rollback/tiny_arena.h
+  Brawlback/include/incremental-rollback/util.h
   Brawlback/Netplay/Matchmaking.cpp
```

**Windows Impact:** ✅ SAFE
- CMakeLists.txt is not used for Windows MSVC builds (they use .sln/.vcxproj)
- If Windows switches to CMake builds in the future, this would be required anyway
- No runtime impact

**Thought Process:**
This is a straightforward build system fix. The files exist and are used, they just weren't listed in CMake.

---

### Commit 4: Add Qt6::GuiPrivate dependency for Linux build (8b36b64d)

**File:** `Source/Core/DolphinQt/CMakeLists.txt`

**Problem:**
Build failed with missing Qt private headers on Linux.

**The Fix:**
```cmake
-find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Svg)
+find_package(Qt6 REQUIRED COMPONENTS Core Gui GuiPrivate Widgets Svg)
...
 target_link_libraries(dolphin-emu
 PRIVATE
   core
   Qt6::Widgets
+  Qt6::GuiPrivate
```

**Windows Impact:** ⚠️ NEEDS TESTING
- Qt6::GuiPrivate should be available on Windows Qt6 installations
- If Windows uses Qt5, this would need to be conditional
- Recommend testing on Windows before merging

**Thought Process:**
Some Dolphin Qt code uses Qt private APIs (QPA - Qt Platform Abstraction). On Linux, these require explicit linking to GuiPrivate. I'm not 100% sure if this is needed on Windows or if Windows builds link it implicitly.

---

### Commit 5: Implement lazy initialization for IncrementalRB (3bf5e341)

**Files:**
- `Source/Core/Core/Brawlback/include/incremental-rollback/incremental_rb.cpp`
- `Source/Core/Core/Brawlback/include/incremental-rollback/incremental_rb.h`
- `Source/Core/Core/HW/EXI/EXIBrawlback.cpp`
- `Source/Core/Core/HW/Memmap.cpp`

**Problem:**
Dolphin crashed during boot with:
```
Unknown Pointer 0x14000000 PC 0x00000000 LR 0x00000000
```

The address `0x14000000` is the end of Wii EXRAM (64MB: `0x10000000`-`0x14000000`).

**Root Cause Analysis:**
`IncrementalRB::InitState()` was being called in `Memmap.cpp`'s `Init()` function during early boot. At this point:
1. Memory regions were allocated but not fully initialized
2. Game hadn't loaded yet
3. Some physical memory regions weren't active

The code was trying to call `TrackAlloc()` on memory regions that weren't ready, and `GetPointer()` for addresses in EXRAM that weren't mapped yet.

**Why This Happened on Linux But Not Windows:**
Windows's `VirtualAlloc` with `MEM_WRITE_WATCH` may handle uninitialized regions differently, or the memory is mapped earlier. On Linux with `mprotect`, accessing unmapped memory causes an immediate crash.

**The Fix:**
Created a lazy initialization pattern:

1. **New API functions:**
```cpp
void RegisterCallbacks(IncrementalRBCallbacks cb);  // Store callbacks only
bool IsInitialized();                                 // Check state
void EnsureInitialized();                            // Lazy init
```

2. **Changed Memmap.cpp to register callbacks instead of initializing:**
```cpp
-  IncrementalRB::InitState(cbs);
+  IncrementalRB::RegisterCallbacks(cbs);
```

3. **Added initialization call when netplay actually starts:**
```cpp
void CEXIBrawlback::SaveState(bu32 frame)
{
+  // Lazy initialization: only init IncrementalRB when netplay actually needs it
+  IncrementalRB::EnsureInitialized();
   IncrementalRB::SaveWrittenPages(frame - 1, ...);
}
```

4. **Added extensive debug logging** to help troubleshoot future issues:
```cpp
INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - START");
INFO_LOG_FMT(BRAWLBACK, "IncrementalRB::InitState() - Getting physical regions");
// ... etc
```

5. **Fixed a Linux socket bug** (found while investigating):
```cpp
-  setsockopt(this->peer->socket, SOL_SOCKET, SO_PRIORITY, &priority, sizeof(priority));
+  setsockopt(this->server->socket, SOL_SOCKET, SO_PRIORITY, &priority, sizeof(priority));
```

**Windows Impact:** ✅ SAFE AND BENEFICIAL
- The lazy initialization pattern is safer on all platforms
- Initialization only happens when netplay is actually used
- If a user plays offline, IncrementalRB is never initialized (saves resources)
- The debug logging can be disabled by setting Brawlback log level to Warning
- The socket fix corrects a bug that existed on Linux (peer vs server variable)

**Thought Process:**
I considered several approaches:
1. **Initialize later in boot sequence** - Would require understanding Dolphin's boot order
2. **Check if memory is ready before InitState** - Complex and error-prone
3. **Lazy initialization** (chosen) - Cleanest solution, defers initialization until we know memory is ready

The key insight was that IncrementalRB is ONLY needed for netplay. By deferring initialization to the first `SaveState()` call (which only happens during netplay), we guarantee that:
- The game has fully loaded
- All memory regions are active
- Netplay has actually started

---

### Commit 6: Fix IncrementalRB Linux compatibility issues (88c24921)

**Files:**
- `Source/Core/Core/Brawlback/include/incremental-rollback/mem.cpp`
- `Source/Core/Core/Brawlback/include/incremental-rollback/tiny_arena.h`
- `Source/Core/Core/Brawlback/include/incremental-rollback/util.h`

**Problems Fixed:**

#### A. Missing includes and platform-specific headers
```cpp
+#include <cerrno>
+#include <cinttypes>
+#include <cstdlib>
+#include <cstring>
...
+#ifdef _WIN32
+#include <malloc.h>
+#else
+#include <mm_malloc.h>
+#endif
```
GCC requires explicit includes for `errno`, `PRIu64`, `strerror`, etc.

#### B. printf format specifier for u64
```cpp
-        printf("%llu : %llu\n", PageIndex, changedOffset);
+        printf("%" PRIu64 " : %" PRIu64 "\n", PageIndex, changedOffset);
```
`%llu` is not portable. `PRIu64` from `<cinttypes>` is the correct cross-platform format specifier.

#### C. Error message for mprotect failure
```cpp
+#ifdef _WIN32
               DWORD dw = GetLastError();
               ERROR_LOG_FMT(BRAWLBACK, "... THE REASON IS: {}\n", dw);
+#else
+              ERROR_LOG_FMT(BRAWLBACK, "... THE REASON IS: {}\n", strerror(errno));
+#endif
```
Linux uses `errno` and `strerror()` instead of `GetLastError()`.

#### D. AVX function attribute
```cpp
+#ifdef _MSC_VER
 void fastMemcpy(void *pvDest, void *pvSrc, size_t nBytes)
+#else
+__attribute__((target("avx,avx2")))
+void fastMemcpy(void *pvDest, void *pvSrc, size_t nBytes)
+#endif
```
GCC requires explicit target attributes to use AVX intrinsics. MSVC enables them via project settings.

#### E. Template definition order in tiny_arena.h
```cpp
+// Forward declarations - must come before template functions that use them
 Arena arena_init(void* backing_buffer, size_t arena_size);
+...
+
+// Macro and template definitions come after forward declarations
 #define arena_alloc_type(arena, type, num) ((type*)arena_alloc(arena, sizeof(type) * num))
```
GCC is stricter about declaration order. The template function `arena_alloc_and_init` was using `arena_alloc_type` before it was defined.

#### F. Explicit namespace qualification
```cpp
-    percentOutOf100 = Clamp(percentOutOf100, 0u, 100u);
+    percentOutOf100 = ::Clamp(percentOutOf100, 0u, 100u);
```
GCC's ADL (Argument-Dependent Lookup) was finding the wrong `Clamp` function. Explicit `::` qualification ensures the global template is used.

**Windows Impact:** ✅ SAFE
- All changes are either guarded by `#ifdef _WIN32` / `#ifdef _MSC_VER`
- Or are improvements that work on both platforms (PRIu64, declaration order)
- The `::Clamp` fix is safer on all platforms

**Thought Process:**
These are all standard cross-platform C++ fixes. I aimed to use the most portable solutions:
- `<cinttypes>` for format specifiers
- `#ifdef` guards for platform-specific code
- Explicit qualification to avoid ADL issues

---

### Commit 7: Fix minizip-ng CMakeLists missing includes (d2c5d1f7)

**File:** `Externals/minizip-ng/CMakeLists.txt`

**Problem:**
Build failed with:
```
Unknown CMake command "check_function_exists"
```

**Root Cause Analysis:**
The minizip-ng CMakeLists.txt uses `check_function_exists()` and `check_include_file()` macros, but doesn't include the CMake modules that define them. On some systems/CMake versions, these are included automatically; on others, they're not.

**The Fix:**
```cmake
 project(minizip C)

+include(CheckFunctionExists)
+include(CheckIncludeFile)
+
 add_library(minizip STATIC
```

**Windows Impact:** ✅ SAFE
- These CMake include() calls are harmless on all platforms
- They just ensure the required macros are available
- This is a proper CMake fix that should be upstreamed to minizip-ng itself

---

### Commit 8: Add EnsureInitialized() to all IncrementalRB::Rollback call sites (a0f76edf)

**File:** `Source/Core/Core/HW/EXI/EXIBrawlback.cpp`

**Problem:**
After implementing lazy initialization in commit 5, I discovered that `Rollback()` can be called before `SaveState()` in two scenarios:

1. **handleLoadSavestate()** - When receiving opponent's savestate
2. **updateSync()** - When rollback is triggered during frame synchronization

If either of these is called first, `IncrementalRB` would not be initialized, causing null pointer access.

**The Fix:**
```cpp
void CEXIBrawlback::handleLoadSavestate(u8* data)
{
  std::memcpy(&stopRollbackFrame, data, sizeof(bu32));
  stopRollbackFrame = swap_endian(stopRollbackFrame);
+  IncrementalRB::EnsureInitialized();
  IncrementalRB::Rollback(this->lastStatedFrame, stopRollbackFrame);
}

...

void CEXIBrawlback::updateSync(bu32& locFrame, bu8 playerIdx)
{
  ...
  if (/* should rollback */) {
    INFO_LOG_FMT(BRAWLBACK, "Should rollback! ...");
+    IncrementalRB::EnsureInitialized();
    IncrementalRB::Rollback(locFrame, latestConfirmedFrame);
```

**Windows Impact:** ✅ SAFE AND FIXES POTENTIAL BUG
- `EnsureInitialized()` is a no-op if already initialized
- This fixes a race condition that could theoretically happen on Windows too
- The overhead is one boolean check per call (negligible)

**Thought Process:**
When analyzing the Brawlback netplay code, I found three entry points that use IncrementalRB:
1. `SaveState()` - Host saves game state (already had EnsureInitialized)
2. `handleLoadSavestate()` - Client receives savestate from host
3. `updateSync()` - Either player triggers rollback

I realized that in a client-host scenario:
- Client might receive opponent's savestate BEFORE ever calling SaveState locally
- This would call Rollback on uninitialized IncrementalRB

The fix is simple: guard ALL Rollback calls with EnsureInitialized.

---

## Testing Performed

### Linux Testing
- [x] Dolphin builds successfully
- [x] Dolphin launches without crashes
- [x] Brawlback ELF boots to character select screen
- [x] Brawlback plugin loads (Syringe 0.6.0, Brawlback-Online v0.0.1)
- [x] GC adapter is detected
- [x] Invalid read errors are suppressed and logged (not a code issue - see notes)
- [ ] Netplay connection - BLOCKED (matchmaking server offline)
- [ ] Rollback during gameplay - BLOCKED (requires netplay)

### Windows Testing
- [ ] Not tested - I don't have Windows

### Invalid Read Errors Note
During testing, I observed recurring "Invalid read" errors:
```
Invalid read from 0x000033f6, PC = 0x800ccebc
```

These are NOT caused by my changes. The PC address `0x800ccebc` is in Brawl's WiFi networking code, near a function (`0x800ccec4`) that Brawlback hooks and replaces with `ReturnImmediately`. The game's network code tries to access uninitialized structures because Brawlback bypasses Nintendo WFC.

These errors can be suppressed by setting `UsePanicHandlers = False` in Dolphin.ini. They're logged but don't affect gameplay.

---

## Files Changed Summary

```
Source/Core/Core/HW/Wiimote.cpp                          | +5 -1  (bounds check)
Source/Core/Common/MemArenaUnix.cpp                      | +23    (mprotect wrapper)
Source/Core/Core/IOS/FS/FileSystemProxy.cpp              | +6     (PAGE_* constants)
Source/Core/Core/IOS/SDIO/SDIOSlot0.cpp                  | +6     (PAGE_* constants)
Source/Core/Core/CMakeLists.txt                          | +9     (source files)
Source/Core/DolphinQt/CMakeLists.txt                     | +2 -1  (Qt6::GuiPrivate)
Source/Core/Core/Brawlback/.../incremental_rb.cpp        | +72    (lazy init + logging)
Source/Core/Core/Brawlback/.../incremental_rb.h          | +10    (new API)
Source/Core/Core/HW/EXI/EXIBrawlback.cpp                 | +8 -2  (EnsureInitialized)
Source/Core/Core/HW/Memmap.cpp                           | +9 -1  (RegisterCallbacks)
Source/Core/Core/Brawlback/.../mem.cpp                   | +25    (Linux compat)
Source/Core/Core/Brawlback/.../tiny_arena.h              | reorder (declaration order)
Source/Core/Core/Brawlback/.../util.h                    | +1 -1  (namespace fix)
Externals/minizip-ng/CMakeLists.txt                      | +3     (CMake includes)
```

---

## Recommendations

1. **Merge commits 1, 5, 8** - These fix real bugs that could affect Windows too
2. **Merge commits 2, 3, 6, 7** - These are Linux-only build fixes, safe for Windows
3. **Test commit 4 on Windows** - Qt6::GuiPrivate may or may not be needed

---

## Questions for Reviewers

1. Does Windows use CMake or Visual Studio project files for building?
2. Is Qt6::GuiPrivate already linked on Windows builds?
3. Should the debug logging in IncrementalRB be removed or kept for troubleshooting?
4. Are there any other code paths that call IncrementalRB::Rollback() that I missed?
