### PR TITLE
Fix Linux build compatibility issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -672,7 +672,7 @@ dolphin_make_imported_target_if_missing(LibLZMA::LibLZMA LIBLZMA)
 
 dolphin_find_optional_system_library_pkgconfig(ZSTD libzstd>=1.4.0 zstd::zstd Externals/zstd)
 
-dolphin_find_optional_system_library_pkgconfig(ZLIB zlib-ng ZLIB::ZLIB Externals/zlib-ng)
+dolphin_find_optional_system_library_pkgconfig(ZLIB zlib ZLIB::ZLIB Externals/zlib-ng)
 
 dolphin_find_optional_system_library_pkgconfig(MINIZIP
   "minizip>=4.0.4" minizip::minizip Externals/minizip-ng

--- a/Externals/discord-rpc/CMakeLists.txt
+++ b/Externals/discord-rpc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.2.0)
+cmake_minimum_required (VERSION 3.5)
 project (DiscordRPC)
 
 include(GNUInstallDirs)

--- a/Externals/minizip-ng/CMakeLists.txt
+++ b/Externals/minizip-ng/CMakeLists.txt
@@ -1,5 +1,8 @@
 project(minizip C)
 
+include(CheckFunctionExists)
+include(CheckIncludeFile)
+
 add_library(minizip STATIC
   minizip-ng/mz.h
   minizip-ng/mz_compat.c

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -14,7 +14,8 @@ endif()
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
-find_package(Qt6 REQUIRED COMPONENTS Core Gui GuiPrivate Widgets Svg)
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Svg)
+find_package(Qt6 QUIET COMPONENTS GuiPrivate)
 message(STATUS "Found Qt version ${Qt6_VERSION}")
 
 set_property(TARGET Qt6::Core PROPERTY INTERFACE_COMPILE_FEATURES "")
@@ -420,11 +421,14 @@ target_link_libraries(dolphin-emu
 PRIVATE
   core
   Qt6::Widgets
-  Qt6::GuiPrivate
   uicommon
   imgui
   implot
 )
+
+if(TARGET Qt6::GuiPrivate)
+  target_link_libraries(dolphin-emu PRIVATE Qt6::GuiPrivate)
+endif()
 
 if (WIN32)
   target_link_libraries(dolphin-emu

--- a/Source/Core/DolphinQt/CMakeLists.txt
+++ b/Source/Core/DolphinQt/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
-find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Svg)
+find_package(Qt6 REQUIRED COMPONENTS Core Gui GuiPrivate Widgets Svg)
 message(STATUS "Found Qt version ${Qt6_VERSION}")
 
 set_property(TARGET Qt6::Core PROPERTY INTERFACE_COMPILE_FEATURES "")
@@ -420,6 +420,7 @@ target_link_libraries(dolphin-emu
 PRIVATE
   core
   Qt6::Widgets
+  Qt6::GuiPrivate
   uicommon
   imgui
   implot


### PR DESCRIPTION
## Fix Linux build compatibility

  Fixes build failures on modern Linux distributions (tested: Manjaro, Qt 6.10, CMake 4.0, GCC 15).

  ### Issues Fixed

  | File | Issue | Fix |
  |------|-------|-----|
  | `CMakeLists.txt` | zlib linker error (`undefined reference to deflateInit_`) | Use `zlib` pkg-config instead of `zlib-ng` for standard API |
  | `Externals/minizip-ng/CMakeLists.txt` | CMake configure fails (`Unknown command check_function_exists`) | Add missing CMake module includes |
  | `Externals/discord-rpc/CMakeLists.txt` | CMake 4.x rejects version < 3.5 | Update minimum to 3.5 |
  | `Source/Core/DolphinQt/CMakeLists.txt` | Missing Qt private header | Add `Qt6::GuiPrivate` dependency |

  ### Build
Note: -DUSE_SYSTEM_FMT=OFF is required on systems with fmt 12+. The fmt 12 release has breaking API changes (FMT_COMPILE_STRING → fmt::string_view conversion) that affect the Dolphin codebase. This is an upstream Dolphin issue, not Brawlback-specific. Using the bundled fmt 10.x is the intended solution.

  ```bash
  cmake -DUSE_SYSTEM_FMT=OFF ..  # system fmt 12 has breaking changes
  cmake --build . -j$(nproc)

  Result

  All targets build successfully:
  - dolphin-emu (Qt GUI)
  - dolphin-emu-nogui
  - dolphin-tool